### PR TITLE
Provide a native Android Studio NDK build

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,9 +8,9 @@ android {
         minSdkVersion 14
         targetSdkVersion 27
 
-        ndk {
-            moduleName "xmp-prebuilt"
-        }
+        // ndk {
+        //     moduleName "xmp-prebuilt"
+        // }
     }
     buildTypes {
         release {
@@ -18,11 +18,16 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-project.txt'
         }
     }
-    // Temporarily disable ndk build
-    sourceSets.main {
-        jni.srcDirs = []
-        jniLibs.srcDir 'src/main/libs'
+    externalNativeBuild {
+        ndkBuild {
+            path 'src/main/jni/Android.mk'
+        }
     }
+    // Temporarily disable ndk build
+    // sourceSets.main {
+    //     jni.srcDirs = []
+    //     jniLibs.srcDir 'src/main/libs'
+    // }
     productFlavors {
     }
 }

--- a/app/src/main/jni/Android.mk
+++ b/app/src/main/jni/Android.mk
@@ -1,17 +1,51 @@
-LOCAL_PATH	:= $(call my-dir)
-#LOCAL_ARM_MODE	:= arm
+# Note: The library (libxmp) must be prebuilt before compiling this to use in the android app.
+# Using Windows 10, with Windows Subsystem for Linux, and Ubuntu installed from the Store.
+# Ubuntu 20.04.1 LTS (Windows Store) is the version at the time of writing this.
+# Ubuntu must be launched, setup, and updated to use.
+# With libxmp sources placed in src/main/jni/sources.
+# Go into the libxmp folder (src\main\jni\libxmp).
+# Open "Open Linux shell here" from the contextual menu.
+#
+# Run the following command (might need to run under SU):
+# autoconf && ./configure && make && make check && (cd test-dev; autoconf && ./configure && make)
+#
+# Note: You might need to install autoconf, and gcc
+# autoconf: sudo apt install autoconf
+# gcc: sudo apt install build-essential
+#
+# [Linux steps should be similar with most of these steps. Refer to below.]
+# Reference: https://github.com/libxmp/libxmp/
+# Reference: https://github.com/libxmp/libxmp/blob/master/INSTALL
+# Reference: https://github.com/libxmp/libxmp/blob/master/jni/Android.mk
+# Reference: https://github.com/libxmp/libxmp/blob/ab70ec9f3a5c9052e022a66338343f8ea87a4220/.travis.yml#L13
+
+LOCAL_PATH := $(call my-dir)/libxmp
 
 include $(CLEAR_VARS)
-LOCAL_MODULE := xmp-prebuilt
-LOCAL_SRC_FILES := ../../../../../../libxmp/obj/local/$(TARGET_ARCH_ABI)/libxmp.a
-include $(PREBUILT_STATIC_LIBRARY)
 
-include $(CLEAR_VARS)
-LOCAL_MODULE	:= xmp-jni
-LOCAL_CFLAGS    := -O3 -I$(LOCAL_PATH)/../../../../../../libxmp/include \
-                   -Wno-int-to-pointer-cast -Wno-pointer-to-int-cast
-LOCAL_STATIC_LIBRARIES := xmp-prebuilt
-LOCAL_SRC_FILES := xmp-jni.c opensl.c
-LOCAL_LDLIBS	:= -lOpenSLES #-llog
+include $(LOCAL_PATH)/src/Makefile
+include $(LOCAL_PATH)/src/loaders/Makefile
+include $(LOCAL_PATH)/src/loaders/prowizard/Makefile
+include $(LOCAL_PATH)/src/depackers/Makefile
+
+SRC_SOURCES	:= $(addprefix src/,$(SRC_OBJS))
+LOADERS_SOURCES := $(addprefix src/loaders/,$(LOADERS_OBJS))
+PROWIZ_SOURCES	:= $(addprefix src/loaders/prowizard/,$(PROWIZ_OBJS))
+DEPACKERS_SOURCES := $(addprefix src/depackers/,$(DEPACKERS_OBJS))
+
+LOCAL_MODULE := libxmp-jni
+
+LOCAL_CFLAGS	:= -O3 -DHAVE_MKSTEMP -DHAVE_FNMATCH -DHAVE_ROUND -I$(LOCAL_PATH)/include \
+		   -I$(LOCAL_PATH)/src
+
+LOCAL_SRC_FILES := $(SRC_SOURCES:.o=.c) \
+		   $(LOADERS_SOURCES:.o=.c) \
+		   $(PROWIZ_SOURCES:.o=.c) \
+		   $(DEPACKERS_SOURCES:.o=.c) \
+		   $(LOCAL_PATH)/../xmp-jni.c \
+		   $(LOCAL_PATH)/../opensl.c
+
+# for native audio
+LOCAL_LDLIBS := -lOpenSLES
 
 include $(BUILD_SHARED_LIBRARY)

--- a/app/src/main/jni/Android.mk
+++ b/app/src/main/jni/Android.mk
@@ -2,16 +2,15 @@
 # Using Windows 10, with Windows Subsystem for Linux, and Ubuntu installed from the Store.
 # Ubuntu 20.04.1 LTS (Windows Store) is the version at the time of writing this.
 # Ubuntu must be launched, setup, and updated to use.
-# With libxmp sources placed in src/main/jni/sources.
-# Go into the libxmp folder (src\main\jni\libxmp).
-# Open "Open Linux shell here" from the contextual menu.
-#
-# Run the following command (might need to run under SU):
-# autoconf && ./configure && make && make check && (cd test-dev; autoconf && ./configure && make)
+# With libxmp sources placed in src\main\jni\libxmp.
+# Navigate into the libxmp folder and click "Open Linux shell here" from the contextual menu.
 #
 # Note: You might need to install autoconf, and gcc
 # autoconf: sudo apt install autoconf
 # gcc: sudo apt install build-essential
+#
+# Run the following command (might need to run under SU):
+# autoconf && ./configure && make && make check && (cd test-dev; autoconf && ./configure && make)
 #
 # [Linux steps should be similar with most of these steps. Refer to below.]
 # Reference: https://github.com/libxmp/libxmp/
@@ -28,14 +27,14 @@ include $(LOCAL_PATH)/src/loaders/Makefile
 include $(LOCAL_PATH)/src/loaders/prowizard/Makefile
 include $(LOCAL_PATH)/src/depackers/Makefile
 
-SRC_SOURCES	:= $(addprefix src/,$(SRC_OBJS))
+SRC_SOURCES := $(addprefix src/,$(SRC_OBJS))
 LOADERS_SOURCES := $(addprefix src/loaders/,$(LOADERS_OBJS))
-PROWIZ_SOURCES	:= $(addprefix src/loaders/prowizard/,$(PROWIZ_OBJS))
+PROWIZ_SOURCES := $(addprefix src/loaders/prowizard/,$(PROWIZ_OBJS))
 DEPACKERS_SOURCES := $(addprefix src/depackers/,$(DEPACKERS_OBJS))
 
 LOCAL_MODULE := libxmp-jni
 
-LOCAL_CFLAGS	:= -O3 -DHAVE_MKSTEMP -DHAVE_FNMATCH -DHAVE_ROUND -I$(LOCAL_PATH)/include \
+LOCAL_CFLAGS := -O3 -DHAVE_MKSTEMP -DHAVE_FNMATCH -DHAVE_ROUND -I$(LOCAL_PATH)/include \
 		   -I$(LOCAL_PATH)/src
 
 LOCAL_SRC_FILES := $(SRC_SOURCES:.o=.c) \


### PR DESCRIPTION
I was able to use the Android.mk file from libxmp and tweak it a bit for Android Studio to compile libxmp natively within Xmp Android. 

The commit assumes libxmp is in 'src/main/jni/' and libxmp  is precompiled with the object files to compile within Android Studio

It was able to successfully compile the following binaries: x86_64, x86, arm64-v8a, and armeabi-v7a

Due to the outdated nature of gradle and the project itself. I had to manually define my NDK Location within the project structure. Once the project/gradle is updated, it will be able to use ndkVersion within the build.gradle file. 


I'm pretty sure this can be done much better, along with Android Studio fetching and compiling everything in one go.