### PR TITLE
Stop ProgressThread leak.

### DIFF
--- a/app/src/main/java/org/helllabs/android/xmp/player/PlayerActivity.java
+++ b/app/src/main/java/org/helllabs/android/xmp/player/PlayerActivity.java
@@ -803,6 +803,12 @@ public class PlayerActivity extends Activity {
 			Log.i(TAG, "Can't unbind unregistered service");
 		}
 
+		stopUpdate = true;
+		if(progressThread != null && progressThread.isAlive()) {
+			progressThread.interrupt();
+			progressThread = null;
+		}
+
 		super.onDestroy();
 	}
 


### PR DESCRIPTION
Earlier this year, Leak Canary reported progressThread was leaking when the activity was destroyed. 

This should make sure progressThread is stopped and cleaned up once the activity is destroyed. 